### PR TITLE
Fix: Intersection to be passed as an array.

### DIFF
--- a/zray.php
+++ b/zray.php
@@ -95,7 +95,8 @@ class Magento {
 		/// collect event targets for events collector
 		$event = $context['functionArgs'][0];
 		$args = $context['functionArgs'][1];
-		$key = array_shift(array_intersect(array('object', 'resource', 'collection', 'front', 'controller_action'), array_keys($args)));
+		$intersection = array_intersect(array('object', 'resource', 'collection', 'front', 'controller_action'), array_keys($args));
+		$key = array_shift($intersection);
 		$this->eventTargets[$event] = $args[$key];
 	}
 	


### PR DESCRIPTION
With Magento Developer Mode enabled I was getting an error "Strict Standards: Only variables should be passed by reference" for line 95.
array_shift expects the parameter to be a variable rather than a function in strict mode.