### PR TITLE
Fixed problem for php 5.4

### DIFF
--- a/zray.php
+++ b/zray.php
@@ -112,15 +112,17 @@ class Magento {
 	 * @param array $context
 	 */
 	public function mageDispatchEvent($context) {
-		/// collect event targets for events collector
-		$event = $context['functionArgs'][0];
-		$args = isset($context['functionArgs'][1]) ? $context['functionArgs'][1] : array();
-		$intersection = array_intersect(array('object', 'resource', 'collection', 'front', 'controller_action'), array_keys($args));
-		$key = array_shift($intersection);
-		if(isset($args[$key])){
-			$this->eventTargets[$event] = $args[$key];
-		}
-	}
+        	/// collect event targets for events collector
+                $event = $context['functionArgs'][0];
+                if (isset($context['functionArgs'][1])) {
+                        $args = $context['functionArgs'][1];
+                        $array = array_intersect(array('object', 'resource', 'collection', 'front', 'controller_action'),array_keys($args));
+                        $key = array_shift($array);
+                        if (isset($args[$key])) {
+                                $this->eventTargets[$event] = $args[$key];
+                        }
+        	}
+        }
 	
 	/**
 	 * @param array $context


### PR DESCRIPTION
to array_shift there need to be passed a reference instead the newly created array.
Also, not always $context contains all required variables.